### PR TITLE
Scrapy server deploy

### DIFF
--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -142,6 +142,7 @@ const Landing = (props) => {
           setOutputMode('words');
         } else {
           // Make a 'POST' request to scrape the website
+          setIsLoading(false);
           setIsScraping(true);
           await axios.post(`${BASE_URL}/scrapy/scrape`, { url: urlInput });
         }

--- a/scraper/.gitignore
+++ b/scraper/.gitignore
@@ -5,3 +5,6 @@ __pycache__
 project.egg*
 setup.py
 scrapinghub.yml
+/logs
+/eggs
+/dbs

--- a/scraper/scrapy.cfg
+++ b/scraper/scrapy.cfg
@@ -11,8 +11,8 @@ default = domainScraper.settings
 bind_address = 0.0.0.0
 poll_interval = 1.0
 
-[deploy]
-#url = http://localhost:6800/
+[deploy:local]
+url = http://localhost:6800/
 project = domainScraper
 
 # used for deploying to scrapyd server

--- a/scraper/scrapy.cfg
+++ b/scraper/scrapy.cfg
@@ -6,6 +6,16 @@
 [settings]
 default = domainScraper.settings
 
+# settings for scrapyd server
+[scrapyd]
+bind_address = 0.0.0.0
+poll_interval = 1.0
+
 [deploy]
 #url = http://localhost:6800/
+project = domainScraper
+
+# used for deploying to scrapyd server
+[deploy:prod]
+#url = http://<serverip>:6800/
 project = domainScraper

--- a/server/controllers/scrapy.js
+++ b/server/controllers/scrapy.js
@@ -1,33 +1,40 @@
 // controller for handling scraped data
-import axios from 'axios';
+import axios from "axios";
 import Data from "../models/data.js";
 
 import { MONGO_URI, DB, PROJECT, SCRAPYD_URL } from "../utils/envSetup.js";
 
+/**
+ * Function to scrape a website
+ * Sends a POST request to the Scrapyd API to schedule a scraping job
+ * @param {*} req
+ * @param {*} res
+ */
 const scrape = async (req, res) => {
-    const { url } = req.body;
-    try {
+  const { url } = req.body;
+  try {
     const response = await axios.post(`${SCRAPYD_URL}/schedule.json`,
+      // arguments for scheduling a scraping job
       new URLSearchParams({
-          'project': PROJECT,
-          'spider': 'spider',
-          'url': url,
-          'MONGO_DB': DB,
-          'MONGO_URI': MONGO_URI,
-          'MONGO_COLLECTION': Data.collection.name,
-      }),
-    )
+        project: PROJECT,
+        spider: "spider",
+        url: url,
+        MONGO_DB: DB,
+        MONGO_URI: MONGO_URI,
+        MONGO_COLLECTION: Data.collection.name,
+      })
+    );
     return res.status(200).json({ success: true, data: response.data });
-    } catch (err) {
-        return res.status(500).json({
-            msg: err.message || "Something went wrong while getting data.",
-        });
-    }
-}
+  } catch (err) {
+    return res.status(500).json({
+      msg: err.message || "Something went wrong while getting data.",
+    });
+  }
+};
 
 const getDomains = async (req, res) => {
   try {
-    const data = await Data.find().distinct('domain');
+    const data = await Data.find().distinct("domain");
     return res.status(200).json({ success: true, data: data });
   } catch (err) {
     return res.status(500).json({

--- a/server/controllers/scrapy.js
+++ b/server/controllers/scrapy.js
@@ -2,24 +2,21 @@
 import axios from 'axios';
 import Data from "../models/data.js";
 
-import { MONGO_URI } from '../utils/envSetup.js';
+import { MONGO_URI, DB, PROJECT, SCRAPYD_URL } from "../utils/envSetup.js";
 
 const scrape = async (req, res) => {
     const { url } = req.body;
     try {
-    const response = await axios.post('https://app.scrapinghub.com/api/run.json',
-        new URLSearchParams({
-            'project': process.env.PROJECT_ID,
-            'spider': 'spider',
-            'url': url,
-            'MONGO_DB': process.env.DB,
-            'MONGO_URI': MONGO_URI,
-            'MONGO_COLLECTION': Data.collection.name,
-        }), {
-        auth: {
-            username: process.env.API_KEY,
-        }
-    })
+    const response = await axios.post(`${SCRAPYD_URL}/schedule.json`,
+      new URLSearchParams({
+          'project': PROJECT,
+          'spider': 'spider',
+          'url': url,
+          'MONGO_DB': DB,
+          'MONGO_URI': MONGO_URI,
+          'MONGO_COLLECTION': Data.collection.name,
+      }),
+    )
     return res.status(200).json({ success: true, data: response.data });
     } catch (err) {
         return res.status(500).json({
@@ -29,39 +26,39 @@ const scrape = async (req, res) => {
 }
 
 const getDomains = async (req, res) => {
-    try {
-        const data = await Data.find().distinct('domain');
-        return res.status(200).json({ success: true, data: data });
-    } catch (err) {
-        return res.status(500).json({
-            msg: err.message || "Something went wrong while getting data.",
-        });
-    }
-}
+  try {
+    const data = await Data.find().distinct('domain');
+    return res.status(200).json({ success: true, data: data });
+  } catch (err) {
+    return res.status(500).json({
+      msg: err.message || "Something went wrong while getting data.",
+    });
+  }
+};
 
 const getData = async (req, res) => {
-    const { domain } = req.query;
-    try {
-        const data = domain ? await Data.findOne({ domain }) : await Data.find();
-        return res.status(200).json({ success: true, data: data });
-    } catch (err) {
-        return res.status(500).json({
-            msg: err.message || "Something went wrong while getting data.",
-        });
-    }
-}
+  const { domain } = req.query;
+  try {
+    const data = domain ? await Data.findOne({ domain }) : await Data.find();
+    return res.status(200).json({ success: true, data: data });
+  } catch (err) {
+    return res.status(500).json({
+      msg: err.message || "Something went wrong while getting data.",
+    });
+  }
+};
 
 const saveData = async (req, res) => {
-    const { domain, URL, text } = req.body;
-    const scrapeDate = Date.now();
-    try {
-        const data = await Data.create({ domain, URL, text, scrapeDate });
-        return res.status(201).json({ success: true, data: data });
-    } catch (err) {
-        return res.status(500).json({
-            msg: err.message || "Something went wrong while scraping data.",
-        });
-    }
-}
+  const { domain, URL, text } = req.body;
+  const scrapeDate = Date.now();
+  try {
+    const data = await Data.create({ domain, URL, text, scrapeDate });
+    return res.status(201).json({ success: true, data: data });
+  } catch (err) {
+    return res.status(500).json({
+      msg: err.message || "Something went wrong while scraping data.",
+    });
+  }
+};
 
 export { scrape, getDomains, getData, saveData };

--- a/server/example.env
+++ b/server/example.env
@@ -23,6 +23,6 @@ GITHUB_CLIENT_ID = < >
 GITHUB_CLIENT_SECRET = < >
 
 # Scrapy Config
-PROJECT_ID = < Zyte project id> 
+PROJECT = <name e.g domainScraper> 
+SCRAPYD_URL = <scrapyd server url>
 DB = < database environment e.g dev > 
-API_KEY = < Zyte auth >

--- a/server/example.env
+++ b/server/example.env
@@ -24,5 +24,5 @@ GITHUB_CLIENT_SECRET = < >
 
 # Scrapy Config
 PROJECT = <name e.g domainScraper> 
-SCRAPYD_URL = <scrapyd server url>
+SCRAPYD_URL = <scrapyd server url> # e.g http://localhost:6800
 DB = < database environment e.g dev > 

--- a/server/utils/envSetup.js
+++ b/server/utils/envSetup.js
@@ -4,8 +4,15 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
+// SCRAPY
+export const DB = process.env.DB;
+export const PROJECT = process.env.PROJECT;
+export const SCRAPYD_URL = process.env.SCRAPYD_URL;
+// CLIENT
 export const BASE_URL = process.env.NODE_ENV === "production" ? process.env.CORS_ORIGIN_PROD : process.env.CORS_ORIGIN_DEV;
+// API
 export const CALLBACK_URL = process.env.NODE_ENV === "production" ? process.env.CALLBACK_URL_PROD : process.env.CALLBACK_URL_DEV;
+// DB
 export const MONGO_URI = process.env.NODE_ENV === "production" ? process.env.MONGO_URI_PROD
     : process.env.NODE_ENV === "development" ? process.env.MONGO_URI_DEV
     : process.env.MONGO_URI_TEST;

--- a/server/utils/getTokenUserData.js
+++ b/server/utils/getTokenUserData.js
@@ -1,5 +1,5 @@
 const getTokenUserData = (user) => {
-    return { username: user.username, userId: user._id, role: user.role }
-  }
+  return { username: user.username, userId: user._id, role: user.role }
+}
   
-  export default getTokenUserData
+export default getTokenUserData


### PR DESCRIPTION
**Changes:**
Deployed the spider from Scrapy project to a [scrapyd](https://scrapyd.readthedocs.io/en/latest/) server. This should allow for faster and simultaneous scraping.
Refactored the backend to now send scrape requests using the scrapyd API. [Documentation](https://scrapyd.readthedocs.io/en/latest/api.html#) 
Updated '/scraper/scrapy.cfg' with settings for the scrapyd server and deployment.

**Notes:**
To create a new deploy, refer to '/scraper/scrapy.cfg' ```[deploy]``` section.
I used [scrapyd-client](https://github.com/scrapy/scrapyd-client) for deploying as it simplifies the process.
If testing a request from the API endpoint 'backend url/scrapy/scrape' or frontend, check example.env for the changes and update variables.

---
**Example local deploy and usage:** 
- Install scrapyd and scrapyd-client ```sudo pip install scrapyd scrapyd-client```
- Change directory to '/scraper'
- Start scrapyd server by using ```scrapyd```
- In another terminal, run ```scrapyd-deploy local``` to deploy
- To run a test job use ```curl http://localhost:6800/schedule.json -d project=domainScraper -d spider=spider```
- Open ```http://localhost:6800/``` for scrapyd web UI where you can see list of jobs.
---
**Scrapyd web UI:**
![Capture](https://github.com/RozadoStudioProjectsOP/web_domains_analytics/assets/83618002/295c34fa-2725-427c-8221-47f814f46c05)
