### PR TITLE
Crawl length option

### DIFF
--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -121,7 +121,7 @@ const Landing = (props) => {
       }
     }, [isScraping])
 
-    const getURL = async (urlInput) => {
+    const getURL = async (urlInput, LIMIT) => {
 
       setIsLoading(true)
       if (urlInput === "") {
@@ -147,7 +147,7 @@ const Landing = (props) => {
           // Make a 'POST' request to scrape the website
           setIsLoading(false);
           setIsScraping(true);
-          await axios.post(`${BASE_URL}/scrapy/scrape`, { url: urlInput });
+          await axios.post(`${BASE_URL}/scrapy/scrape`, { url: urlInput, LIMIT: LIMIT });
         }
       } catch (error) {
         console.error(error.response.data)
@@ -197,9 +197,9 @@ const Landing = (props) => {
       </div>
     )
 
-    const handleSubmitURL = (e) => {
+    const handleSubmitURL = (e, LIMIT) => {
       e.preventDefault()
-      getURL(urlRef.current.value)
+      getURL(urlRef.current.value, LIMIT)
     }  
 
     const handleSubmitWord = (e) => {
@@ -224,7 +224,12 @@ const Landing = (props) => {
         <ProgressBar height={50} width={180}/>
         <h4>Scraping...this may take a while</h4>
       </div>
-    ) : ( <input className={classes.button} onClick={handleSubmitURL} type="submit" value="Select"></input> )
+    ) : ( 
+    <>
+      <input className={classes.button} onClick={(e)=> handleSubmitURL(e, 4)} type="submit" value="Deep Scrape"></input> 
+      <input className={classes.button} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
+    </>
+    )
 
     const ngrams = !isLoading && !isScraping ? (
       <div>

--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -124,7 +124,7 @@ const Landing = (props) => {
         }, 5000);
         return () => clearInterval(interval);
       }
-    }, [isScraping])
+    }, [isScraping, limit])
 
     const getURL = async (urlInput, LIMIT) => {
 
@@ -229,8 +229,8 @@ const Landing = (props) => {
       </div>
     ) : ( 
     <>
-      <input disabled={singlePage == undefined ? false : !singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 4)} type="submit" value="Deep Scrape"></input> 
-      <input disabled={singlePage == undefined ? false : singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
+      <input disabled={singlePage === undefined ? false : !singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 4)} type="submit" value="Deep Scrape"></input> 
+      <input disabled={singlePage === undefined ? false : singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
     </>
     )
 

--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -65,7 +65,6 @@ const useStyles = createUseStyles({
     width: "50%"
   },
   button: {
-    minWidth: '6vw',
     padding: '12px 20px',
     border: 'none',
     borderRadius: 5,
@@ -275,7 +274,7 @@ const Landing = (props) => {
       </div>
     ) : ( 
     <div>
-      <input disabled={singlePage === undefined ? false : !singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 4)} type="submit" value="Deep Scrape"></input> 
+      <input disabled={singlePage === undefined ? false : !singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 50)} type="submit" value="Deep Scrape"></input> 
       <input disabled={singlePage === undefined ? false : singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
     </div>
     )

--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -102,7 +102,6 @@ const Landing = (props) => {
     const wordRef = useRef(); 
     const urlRef = useRef(); 
     const [limit, setLimit] = useState()
-    const [outputMode, setOutputMode] = useState()
     const { domain, changeDomain } = useContext(DomainContext)
     const [url, setUrl] = useState({ words: "" })
     const [singlePage, setSinglePage] = useState(undefined)
@@ -128,7 +127,6 @@ const Landing = (props) => {
             if (res.data.data) {
               setUrl(res.data.data);
               setSinglePage(res.data.data.singlePage)
-              setOutputMode('words');
               setIsScraping(false);
               setIsLoaded(true);
             }

--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -61,7 +61,7 @@ const useStyles = createUseStyles({
     width: "50%"
   },
   button: {
-    width: '6vw',
+    
     padding: '12px 20px',
     border: 'none',
     borderRadius: 5,
@@ -262,21 +262,10 @@ const Landing = (props) => {
         <h4>Scraping...this may take a while</h4>
       </div>
     ) : ( 
-    <>
+    <div>
       <input disabled={singlePage === undefined ? false : !singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 4)} type="submit" value="Deep Scrape"></input> 
       <input disabled={singlePage === undefined ? false : singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
-    </>
-    )
-
-    const ngrams = !isLoading && !isScraping ? (
-      <div>
-        <input className={classes.button} onClick={() => handleModeSelection('words')} type="submit" value="Words"></input>
-        <input className={classes.button} onClick={() => handleModeSelection('bigrams')} type="submit" value="Bigrams"></input>
-        <input className={classes.button} onClick={() => handleModeSelection('trigrams')} type="submit" value="Trigrams"></input>
-        <input className={classes.button} onClick={() => handleModeSelection('ner')} type="submit" value="NER"></input>
-      </div>
-    ) : (
-      <></>
+    </div>
     )
   return (
     <div>

--- a/scraper/domainScraper/items.py
+++ b/scraper/domainScraper/items.py
@@ -12,3 +12,4 @@ class DomainAnalyitcs(Item):
     sentiment = Field()
     AI_Sentiment = Field()
     ner = Field()
+    singlePage = Field()

--- a/scraper/domainScraper/pipelines/AI_Sentiment.py
+++ b/scraper/domainScraper/pipelines/AI_Sentiment.py
@@ -3,7 +3,7 @@ from transformers import pipeline
 import spacy 
 
 emotion = pipeline('sentiment-analysis', model='arpanghoshal/EmoRoBERTa')
-spacy.cli.download("en_core_web_sm") # Can be commented out for local scraping
+
 nlp = spacy.load('en_core_web_sm') 
 
 class AISentimentPipeline:

--- a/scraper/domainScraper/pipelines/mongo.py
+++ b/scraper/domainScraper/pipelines/mongo.py
@@ -51,7 +51,10 @@ class MongoDBPipeline:
         calculateFrequency('trigrams')
         calculateFrequency('ner')
 
-        query = { 'domain': self.payload['domain'] }
+        query = { '$and': [
+            {'domain': self.payload['domain']},
+            {'singlePage': self.payload['singlePage']}
+        ]}
         data = dict(self.payload)        
         self.col.update_one(query, { '$set': data }, upsert=True)
         self.jobs.update_one({ '_id': self.job.inserted_id}, { '$set': { 'pending': False } }, upsert=True)
@@ -66,6 +69,8 @@ class MongoDBPipeline:
         self.counts['bigrams'] += item['counts']['bigrams']
         self.counts['trigrams'] += item['counts']['trigrams']
         self.counts['ner'] += item['counts']['ner']
+
+        self.payload['singlePage'] = item['singlePage']
 
         def buildPayload(wordList, target):
             for key, value in wordList.items():                

--- a/scraper/domainScraper/pipelines/ngrams.py
+++ b/scraper/domainScraper/pipelines/ngrams.py
@@ -6,10 +6,6 @@ from ..items import DomainAnalyitcs
 
 class NGramPipeline: 
 
-    def open_spider(self, spider):     
-        download('punkt')
-        download('stopwords')
-
     def process_item(self, item, spider):
         item = DomainAnalyitcs(item)
         punctuation = ['\'', '\"', ',', '.', ':', ';']

--- a/scraper/domainScraper/settings.py
+++ b/scraper/domainScraper/settings.py
@@ -19,7 +19,7 @@ DEPTH_PRIOPRITY = 1
 # Stops spider when items return meets set amount.
 CLOSESPIDER_ITEMCOUNT=50
 # Stops spider after making set amount of requests.
-CLOSESPIDER_PAGECOUNT=200
+CLOSESPIDER_PAGECOUNT=1
 # Uses fifo method (default lifo) for breadth first crawls.
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleFifoDiskQueue'
 SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.FifoMemoryQueue'

--- a/scraper/domainScraper/spiders/spider1.py
+++ b/scraper/domainScraper/spiders/spider1.py
@@ -15,19 +15,24 @@ class AuthorSpider(scrapy.Spider):
         # the HTML and returns it into the response argument in the parse method.
         yield scrapy.Request(self.url)
 
-    def parse(self, response):      
+    def parse(self, response):     
         # Uses scrapy items as a sort of schema  
-        item = DomainAnalyitcs()
+        item = DomainAnalyitcs()    
         # Sets item domain as the inputted URL
         item['domain'] = self.url
         # Use Trafilatura extraction method to pull text out of the HTML that was
         # downloaded from scrapy into a string.
         item['raw'] = extract(response.body)
-        # Extracts links found in the downloaded HTML, accepts only links that use
-        # the inputted URL as a base, to attempt to get related material.
-        link_extractor = LinkExtractor(allow=self.url, unique=True)
-        # Calls parse method for each link extracted.
-        for link in link_extractor.extract_links(response):
-            yield scrapy.Request(link.url, callback=self.parse)
+
+        if (self.settings.attributes['CLOSESPIDER_PAGECOUNT'].value == "1"):
+            item['singlePage'] = True
+        else:
+            item['singlePage'] = False
+            # Extracts links found in the downloaded HTML, accepts only links that use
+            # the inputted URL as a base, to attempt to get related material.   
+            link_extractor = LinkExtractor(allow=self.url, unique=True)
+            # Calls parse method for each link extracted.        
+            for link in link_extractor.extract_links(response):
+                yield scrapy.Request(link.url, callback=self.parse)
         # Passes item down into the pipeline.
         yield item

--- a/scraper/domainScraper/spiders/spider1.py
+++ b/scraper/domainScraper/spiders/spider1.py
@@ -3,6 +3,7 @@
 
 from trafilatura import extract
 import scrapy
+import tldextract
 from scrapy.linkextractors import LinkExtractor
 from ..items import DomainAnalyitcs
 
@@ -28,9 +29,11 @@ class AuthorSpider(scrapy.Spider):
             item['singlePage'] = True
         else:
             item['singlePage'] = False
-            # Extracts links found in the downloaded HTML, accepts only links that use
-            # the inputted URL as a base, to attempt to get related material.   
-            link_extractor = LinkExtractor(allow=self.url, unique=True)
+            # Extracts the domain from a URL
+            extractDomainResult = tldextract.extract(self.url)
+            domain = '.'.join([extractDomainResult.domain, extractDomainResult.suffix])
+            # Extracts links from current page that are in the same domain.
+            link_extractor = LinkExtractor(allow_domains=domain, unique=True)
             # Calls parse method for each link extracted.        
             for link in link_extractor.extract_links(response):
                 yield scrapy.Request(link.url, callback=self.parse)

--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -13,3 +13,4 @@ spacy == 3.6.0
 transformers == 4.31.0
 torch == 2.0.1
 tensorflow == 2.12.0
+tldextract == 3.4.4

--- a/server/controllers/scrapy.js
+++ b/server/controllers/scrapy.js
@@ -11,7 +11,8 @@ import { MONGO_URI, DB, PROJECT, SCRAPYD_URL } from "../utils/envSetup.js";
  * @param {*} res
  */
 const scrape = async (req, res) => {
-  const { url } = req.body;
+  const { url, LIMIT } = req.body;
+  console.log(LIMIT)
   try {
     const response = await axios.post(`${SCRAPYD_URL}/schedule.json`,
       // arguments for scheduling a scraping job
@@ -22,6 +23,7 @@ const scrape = async (req, res) => {
         MONGO_DB: DB,
         MONGO_URI: MONGO_URI,
         MONGO_COLLECTION: Data.collection.name,
+        setting: `CLOSESPIDER_PAGECOUNT=${LIMIT}`
       })
     );
     return res.status(200).json({ success: true, data: response.data });

--- a/server/controllers/scrapy.js
+++ b/server/controllers/scrapy.js
@@ -46,9 +46,9 @@ const getDomains = async (req, res) => {
 };
 
 const getData = async (req, res) => {
-  const { domain } = req.query;
+  const { domain, limit } = req.query;
   try {
-    const data = domain ? await Data.findOne({ domain }) : await Data.find();
+    const data = domain ? await Data.findOne({ domain, singlePage: limit == 1 ? true : false }) : await Data.find();
     return res.status(200).json({ success: true, data: data });
   } catch (err) {
     return res.status(500).json({

--- a/server/models/data.js
+++ b/server/models/data.js
@@ -4,7 +4,6 @@ import mongoose from "mongoose";
 const wordCloudSchema = new mongoose.Schema({
     domain: {
         type: String,
-        unique: true,
         required: true,
     },
     words: {


### PR DESCRIPTION
I will be creating a feature with the option to crawl from a single page, or from many, so that the user can potentially get related material from other pages. #77 

### Tasks

#### Frontend:
I will simply create options using radio buttons for single page or many, with single page being selected by default.

#### Backend:
Send a request to the scraper with a parameter that overrides the default setting for CLOSESPIDER_PAGECOUNT ( stops the spider when downloaded pages reaches page count).

#### Scraper:
Implement a decision statement that adds a tag to the data about what option the user selected, and whether or not to execute the logic for extracting URLs from a page.

### Changelog:

- Spider can figure out the domain name from the given URL.
- User has the option to get data from a single page or from many.
- When crawling many pages, the spider will extract links from the page, and only follow those that are in the domain of the original URL.
- Added singlePage true/false tag to the data stored in DB