### PR TITLE
Re-scrape

### DIFF
--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { createUseStyles } from "react-jss";
 import { useRef, useState, useEffect, useContext } from 'react';
 import { BASE_URL } from '../utils/base_url';
 import axios from 'axios';
@@ -9,97 +8,10 @@ import Sentiment from './Sentiment';
 import Classification from './Classification';
 import { ProgressBar } from 'react-loader-spinner';
 import { DomainContext } from '../contexts/domains';
+import '../styles/Landing.css'
 
-const useStyles = createUseStyles({
-  page: {
-    height: "auto",
-    background: '#E9EAEC',
-    display: 'flex',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-    '& > div': {
-      display: 'flex',
-      justifyContent: 'space-around',
-      alignItems: 'center',
-      background: 'white',
-      marginBottom: 10,
-      marginLeft: 20,
-      border: "2px solid #385E72",
-      borderRadius: 5,
-      width: '25vw',
-      height: '70vh',
-      minHeight: '70vh',
-      '@media (max-width: 960px)': {
-        width: '99%',
-        marginLeft: 0,
-        height: '80vh',
-      },
-      '& > h3': {
-        fontFamily: 'Gill Sans',
-        fontSize: '1.5rem',
-        letterSpacing: '0.3rem',
-        color: '#191970',
-        whiteSpace: 'nowrap',
-      },
-      '&:nth-child(1)': {
-        flexDirection: 'column',
-      },
-    },
-  },
-  inputs: {
-    display: 'flex',
-    justifyContent: 'space-around',
-    flexWrap: 'wrap',
-    '& > div': {
-      display: 'flex',
-      alignItems: 'center',
-      marginTop: 20,
-      width: '80%',
-    },
-  },
-  wordInput: {
-    padding: 15,
-    fontSize: "1rem",
-    fontWeight: "bold",
-    width: "50%"
-  },
-  button: {
-    padding: '12px 20px',
-    border: 'none',
-    borderRadius: 5,
-    cursor: 'pointer',
-    background: '#D9E4EC',
-    fontWeight: 'bold',
-    fontSize: "1rem",
-    boxShadow: "4px 4px 5px 1px rgba(0, 0, 0, 0.25)",
-    transition: "transform 50ms",
-    '&:hover': {
-        background: '#385E72',
-        color: 'white'
-    },
-    "&:active": {
-        transform: "translateY(4px)",
-        boxShadow: "0px 0px 0px 0px rgba(0, 0, 0, 0.75)",
-    }
-  },
-  buttonDis: {
-    minWidth: '6vw',
-    padding: '12px 20px',
-    border: 'none',
-    borderRadius: 5,
-    background: '#D9E4EC',
-    fontWeight: 'bold',
-    fontSize: "1rem",
-  },
-  results: {
-    color: '#191970',
-    fontSize: "1.2rem"
-  }
-  })
 
 const Landing = (props) => {
-    const classes = useStyles();
     const wordRef = useRef(); 
     const urlRef = useRef(); 
     const [limit, setLimit] = useState()
@@ -222,17 +134,17 @@ const Landing = (props) => {
 
     // Word count conditional output
     const result = wordFound === true ? (
-      <div className={classes.results}>
+      <div className={"results"}>
         <h4>Total: {wordNum.total}</h4>
         <h4>Frequency: {wordNum.frequency}</h4>
       </div>
     ) : wordFound === false ? (
-      <div className={classes.results}>
+      <div className={"results"}>
         <h4>No matches</h4>
         <h4 style={{color: 'white'}}>Total:</h4>
       </div>
     ) : (
-      <div className={classes.results}>
+      <div className={"results"}>
         <h4 style={{color: 'white'}}>Total:</h4>
         <h4 style={{color: 'white'}}>Frequency:</h4>
       </div>
@@ -275,23 +187,23 @@ const Landing = (props) => {
     ) : ( 
     <div>
       <div>
-        <input disabled={singlePage === undefined ? false : !singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 50)} type="submit" value="Deep Scrape"></input> 
-        <input disabled={singlePage === undefined ? false : singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
+        <input disabled={singlePage === undefined ? false : !singlePage} className={"button"} onClick={(e)=> handleSubmitURL(e, 50)} type="submit" value="Deep Scrape"></input> 
+        <input disabled={singlePage === undefined ? false : singlePage} className={"button"} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
       </div>
       <div>
-        <input disabled={singlePage === undefined ? false : true} className={classes.button} type='submit' value='Re-Scrape'></input>
+        <input disabled={singlePage === undefined ? false : true} className={"button"} type='submit' value='Re-Scrape'></input>
       </div>
     </div>
     )
   return (
     <div>
-      <div className={classes.page}>
+      <div className={"page"}>
         <div>
           <h3>Choose a URL</h3>
-          <div className={classes.inputs}>  
+          <div className={"inputs"}>  
             <input
                 disabled={isScraping}
-                className={classes.wordInput}
+                className={"wordInput"}
                 type='text'
                 ref={urlRef}
                 placeholder='https://'
@@ -302,16 +214,16 @@ const Landing = (props) => {
             {loading}
           </div>
           <h3>Find n-gram: </h3>
-          <div className={classes.inputs}>  
+          <div className={"inputs"}>  
             {!isLoaded ? (
               <>
-                <input className={classes.wordInput} type='text' ref={wordRef} required disabled></input>
-                <input className={classes.buttonDis} onClick={handleSubmitWord} type="submit" value="Check" disabled></input>
+                <input className={"wordInput"} type='text' ref={wordRef} required disabled></input>
+                <input className={"buttonDis"} onClick={handleSubmitWord} type="submit" value="Check" disabled></input>
               </>
               ) : (
               <>
-                <input className={classes.wordInput} type='text' ref={wordRef} required></input>
-                <input className={classes.button} onClick={handleSubmitWord} type="submit" value="Check"></input>
+                <input className={"wordInput"} type='text' ref={wordRef} required></input>
+                <input className={"button"} onClick={handleSubmitWord} type="submit" value="Check"></input>
               </>
               )
             }

--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -274,8 +274,13 @@ const Landing = (props) => {
       </div>
     ) : ( 
     <div>
-      <input disabled={singlePage === undefined ? false : !singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 50)} type="submit" value="Deep Scrape"></input> 
-      <input disabled={singlePage === undefined ? false : singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
+      <div>
+        <input disabled={singlePage === undefined ? false : !singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 50)} type="submit" value="Deep Scrape"></input> 
+        <input disabled={singlePage === undefined ? false : singlePage} className={classes.button} onClick={(e)=> handleSubmitURL(e, 1)} type="submit" value="Quick Scrape"></input>
+      </div>
+      <div>
+        <input disabled={singlePage === undefined ? false : true} className={classes.button} type='submit' value='Re-Scrape'></input>
+      </div>
     </div>
     )
   return (

--- a/client/src/components/Landing.js
+++ b/client/src/components/Landing.js
@@ -158,16 +158,6 @@ const Landing = (props) => {
     </div>
   )
 
-  const handleSubmitURL = (e, LIMIT) => {
-    e.preventDefault()
-    getURL(urlRef.current.value, LIMIT)
-  }
-
-  const handleSubmitWord = (e) => {
-    e.preventDefault()
-    getWords(wordRef.current.value)
-  }
-
   useEffect(() => {
     // Function to handle screen size changes
     function handleResize() {
@@ -232,7 +222,7 @@ const Landing = (props) => {
           <h3>Find n-gram: </h3>
           <div className={"inputs"}>
             <input disabled={!isLoaded} className={"wordInput"} type='text' ref={wordRef} required></input>
-            <input disabled={!isLoaded} className={"button"} onClick={handleSubmitWord} type="submit" value="Check"></input>
+            <input disabled={!isLoaded} className={"button"} onClick={() => getWords(wordRef.current.value)} type="submit" value="Check"></input>
           </div>
           {result}
         </div>

--- a/client/src/styles/Landing.css
+++ b/client/src/styles/Landing.css
@@ -73,12 +73,12 @@
   transition: transform 50ms;
 }
 
-button:hover {
+.button:hover {
   background: #385E72;
   color: white;
 }
 
-button:active {
+.button:active {
   transform: translateY(4px);
   box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0.75);
 }

--- a/client/src/styles/Landing.css
+++ b/client/src/styles/Landing.css
@@ -1,0 +1,98 @@
+.page {
+  height: auto;
+  background: #E9EAEC;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.page > div {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  background: white;
+  margin-bottom: 10px;
+  margin-left: 20px;  
+  border: 2px solid #385E72;
+  border-radius: 5;
+  width: 25vw;
+  height: 70vh;
+  min-height: 70vh;
+}
+
+@media (max-width: 960px) {
+  .page > div {
+    width: 99%;
+    margin-left: 0;
+    height: 80vh;
+  }
+}
+
+.page > div > h3 {
+  font-family: Gill Sans;
+  font-size: 1.5rem;
+  letter-spacing: 0.3rem;
+  color: #191970;
+  white-space: nowrap;
+}
+
+.page > div:nth-child(1) {
+  flex-direction: column;
+}
+
+.inputs {
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+}
+
+.inputs > div {
+  display: flex;
+  align-items: center;
+  margin-top: 20;
+  width: 80%;
+}
+
+.wordInput {
+  padding: 15;
+  font-size: 1rem;
+  font-weight: bold;
+  width: 50%
+}
+
+.button {
+  padding: 12px 20px;
+  border: none;
+  border-radius: 5;
+  cursor: pointer;
+  background: #D9E4EC;
+  font-weight: bold;
+  font-size: 1rem;
+  box-shadow: 4px 4px 5px 1px rgba(0, 0, 0, 0.25);
+  transition: transform 50ms;
+}
+
+button:hover {
+  background: #385E72;
+  color: white;
+}
+
+button:active {
+  transform: translateY(4px);
+  box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0.75);
+}
+
+.buttonDis {
+  min-width: 6vw;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 5;
+  background: #D9E4EC;
+  font-weight: bold;
+  font-size: 1rem;
+}
+.results {
+  color: #191970;
+  font-size: 1.2rem;
+}


### PR DESCRIPTION
Currently if a site has been scraped, there is no way for a user to scrape again.
So for this PR I will be creating a feature, that allows a user to scrape again, this is useful because the site could change or our algorithm could improve. 

Changes:
- Does not scrape immediately if no data found.
- Option to scrape if data not found, or re-scrape if found.
- Improved UI, it is more clear that crawl lengths are an option.
- Moved Landing CSS to its own file
- Removed some duplicate code.

Before making inputs

![image](https://github.com/RozadoStudioProjectsOP/web_domains_analytics/assets/83617960/54e2c3c2-0ef1-4f9b-a38b-b591d72761c6)

After checking DB, no result

![image](https://github.com/RozadoStudioProjectsOP/web_domains_analytics/assets/83617960/d2852ea5-cd50-435e-94c1-630dd678213e)

After checking DB, confirmed result.

![image](https://github.com/RozadoStudioProjectsOP/web_domains_analytics/assets/83617960/d8a64601-e119-4e35-a91b-ff5bc2ee45b5)


Also I will be trying to implement a smaller scale spider that checks response headers, and tries to detect changes on the page and automatically report this to the user, based on commonly used headers like 'Last-Modified' and 'Content-Length', that might convey that the page has changed. This might be something I do in a future PR.